### PR TITLE
Autologin feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "@cozy/minilog": "1.0.0",
     "cozy-clisk": "^0.20.2",
-    "date-fns": "^2.30.0"
+    "date-fns": "^2.30.0",
+    "p-wait-for": "^5.0.2"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
This PR fixes the I frame problem we encounter for the login page.

We're now finding the url of this I-frame and using it to make the worker go on the login page, avoiding problems with accessing the DOM inside the i-frame. We can now save the user's credentials and make autoLogin with it.

It also adds a check to see if the website is waiting for a confirmation code after the loging (to register the device used), and give back hands to the user if it is.
In the last commit we're increasing the timeout for the confirmation code's check to be sure the user got the time to receive it and write it down in the webview.