### PR TITLE
feat: New way to handle login

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@cozy/minilog": "1.0.0",
-    "cozy-clisk": "^0.20.3",
+    "cozy-clisk": "^0.21.1",
     "date-fns": "^2.30.0",
     "p-wait-for": "^5.0.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ class BouyguesTelecomContentScript extends ContentScript {
     }
     this.log('info', 'No auth detected')
     await this.navigateToLoginForm()
-    srcFromIframe = await this.evaluateInWorker(() => {
+    srcFromIframe = await this.evaluateInWorker(function getSrcFromIFrame() {
       return document
         .querySelector('#bytelid_partial_acoMenu_login')
         .getAttribute('src')
@@ -128,7 +128,7 @@ class BouyguesTelecomContentScript extends ContentScript {
     await this.clickAndWait('[data-id-logout]', '#menu')
 
     // will reload the page after 5s if needed this can confirm the deconnexion in degraded cases
-    await this.evaluateInWorker(() => {
+    await this.evaluateInWorker(function reloadAfter5s() {
       window.setTimeout(() => window.location.reload(), 5000)
     })
     await this.runInWorkerUntilTrue({

--- a/src/index.js
+++ b/src/index.js
@@ -214,11 +214,13 @@ class BouyguesTelecomContentScript extends ContentScript {
     this.log('info', 'getUserDataFromWebsite starts')
     await this.navigateToInfosPage()
     await this.runInWorker('fetchIdentity')
-    await this.saveIdentity(this.store.userIdentity)
+    if (!this.store.userIdentity?.email) {
+      throw new Error(
+        'getUserDataFromWebsite: Could not find email in user identity'
+      )
+    }
     return {
       sourceAccountIdentifier: this.store.userIdentity.email
-        ? this.store.userIdentity.email
-        : 'defaultTemplateSourceAccountIdentifier'
     }
   }
 
@@ -296,7 +298,7 @@ class BouyguesTelecomContentScript extends ContentScript {
     await waitFor(
       () => {
         const loginFormButton = document.querySelector('#login')
-        loginFormButton.click()
+        if (loginFormButton) loginFormButton.click()
 
         if (document.querySelector('#bytelid_partial_acoMenu_login')) {
           return true
@@ -332,6 +334,8 @@ class BouyguesTelecomContentScript extends ContentScript {
       'div[href="/mon-compte/infosperso"] a',
       '.personalInfosAccountDetails'
     )
+    // multiple ajax request update the content. Wait for every content to be present
+    await this.waitForElementInWorker('.title_address')
   }
 
   async navigateToBillsPage() {

--- a/src/index.js
+++ b/src/index.js
@@ -225,6 +225,7 @@ class BouyguesTelecomContentScript extends ContentScript {
   async fetch(context) {
     this.log('info', 'fetch starts')
     await this.saveCredentials(this.store.userCredentials)
+    await this.saveIdentity({ contact: this.store.userIdentity })
     const moreBillsButtonSelector =
       '#page > section > .container > .has-text-centered > a'
     await this.navigateToBillsPage()
@@ -392,13 +393,15 @@ class BouyguesTelecomContentScript extends ContentScript {
         givenName: firstName,
         familyName
       },
-      address: {
-        street,
-        postCode,
-        city,
-        country,
-        formattedAddress: addressElement.replace(/<br>/g, ' ')
-      }
+      address: [
+        {
+          street,
+          postCode,
+          city,
+          country,
+          formattedAddress: addressElement.replace(/<br>/g, ' ')
+        }
+      ]
     }
     await this.sendToPilot({ userIdentity })
     this.log('info', `${JSON.stringify(userIdentity)}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2017,10 +2017,10 @@ cozy-client@^34.11.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-clisk@^0.20.3:
-  version "0.20.3"
-  resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.20.3.tgz#aea89c99a1e015b0f2ef992004bf986a59c3b932"
-  integrity sha512-/dDL+6HivVuLXtoEeJdEfgNhiyziBdtB7HlLWveKXw/hIRYgYHR/V4H7zISVm+qXgrJC6m0i0VMtAnZIiY5aAQ==
+cozy-clisk@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/cozy-clisk/-/cozy-clisk-0.21.1.tgz#5b2258e3f05b5690f0a227667f73d3143a58a46a"
+  integrity sha512-s2UWuofpyT0YEi6irmO4u7KrfjwMOcwELXtTnM653Xoistz+kgWICiv24NnIuJV67EFUfbzXylQf3MdOQkDpkg==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     bluebird-retry "^0.11.0"


### PR DESCRIPTION
With the previous login method, some users with different mobile phone
could not authenticate properly with bouygues telecom

Now we use localStorage data to detect authentication which looks more
stable with my tests

Also fixed ensureNotAuthenticated

Now following cases have been tested :
- first login with unauthenticated webview
- first login with authenticated webview (forces logout)
- second run with authenticated webview
- second run with not authenticated webview