### PR TITLE
[SCR-614] feat: Remove 'telecom' category from manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -9,7 +9,6 @@
   "editor": "Cozy",
   "vendor_link": "https://bouyguestelecom.fr/",
   "categories": [
-    "telecom",
     "isp"
   ],
   "fields": {},


### PR DESCRIPTION
Remove telecom category from manifest for the konnector to be displayed in only one category in the store