### PR TITLE
[SCR-370] fix: Avoid error when 'lignes' array is empty

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -799,10 +799,9 @@ class BouyguesTelecomContentScript extends ContentScript {
     for (const foundBill of foundBills) {
       const fileHref = foundBill.facturePDF[0].href
       // Here we need to check if "mntTotalLigne" is present because this amount contains third-party services payments (like bus tickets payed by phone for example).
-      // If this field is not present, that means the user has no third-party services payment on current bill so we keep using "mntTotalLigne" as it is the subscription's price.
-      const amount = foundBill.lignes[0].mntTotalLigne
-        ? foundBill.lignes[0].mntTotalLigne
-        : foundBill.mntTotFacture
+      // If this field is not present (and "lignes" can be empty or missing too), that means the user has no third-party services payment on current bill so we keep using "mntTotalLigne" as it is the subscription's price.
+      const amount =
+        foundBill.lignes[0]?.mntTotalLigne ?? foundBill.mntTotFacture
       const foundDate = foundBill.dateFacturation
       const vendor = 'Bouygues Telecom'
       const date = new Date(foundDate)


### PR DESCRIPTION
On some user's account, we found out one of the data we were checling to define the amount was empty for some bills (for the user we worked with, it was on a "new type" of bill, bills for reimbursment. Not all of them, but some. This PR fixes it