### PR TITLE
fix: Fix skipping doc condition to avoid errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -510,7 +510,6 @@ class BouyguesTelecomContentScript extends ContentScript {
         foundBills.push(bill)
       })
     }
-    const foundLineNumbers = document.querySelectorAll('.column > .is-nowrap')
     let i = 0
     // ensuring array is sorted from most recent to older
     foundBills.sort(sortDateFn)
@@ -555,8 +554,12 @@ class BouyguesTelecomContentScript extends ContentScript {
           'warn',
           'It seems like no phone number is found, trying to scrape it instead'
         )
+        // Might find something better to avoid errors when no lines number are found at all, it might be a loading error on the website
+        const foundLineNumbers = document.querySelectorAll(
+          '.column > .is-nowrap'
+        )
         // As foundBills has been sorted by date, we can select the element following loops
-        const foundLineNumber = foundLineNumbers[i].textContent.replace(
+        const foundLineNumber = foundLineNumbers[i]?.textContent.replace(
           / /g,
           ''
         )


### PR DESCRIPTION
Simple fix to avoid error in skipping conditions when no lines are found