### PR TITLE
Fix/missing bills

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -860,7 +860,9 @@ class BouyguesTelecomContentScript extends ContentScript {
     await this.goto(monCompteUrl)
     await Promise.race([
       this.waitForElementInWorker('#bytelid_a360_login'),
-      this.runInWorkerUntilTrue({ method: 'waitForUserId' })
+      this.waitForElementInWorker('a', {
+        includesText: 'Me déconnecter'
+      })
     ])
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -689,6 +689,9 @@ class BouyguesTelecomContentScript extends ContentScript {
     // overload ContentScript.downloadFileInWorker to be able to get the token and to run double
     // fetch request necessary to finally get the file
     this.log('debug', 'Override downloading file in worker')
+    // Allow server to breath between downloads, it seems to avoid the 502 recuring error
+    // 1 second is too short, 2 seems sufficient
+    await sleep(2)
     const token = window.sessionStorage.getItem('a360-access_token')
     const body = await ky
       .get(entry.fileurl, {
@@ -909,3 +912,9 @@ connector
   .catch(err => {
     log.warn(err)
   })
+
+function sleep(delay) {
+  return new Promise(resolve => {
+    setTimeout(resolve, delay * 1000)
+  })
+}

--- a/src/index.js
+++ b/src/index.js
@@ -732,6 +732,12 @@ class BouyguesTelecomContentScript extends ContentScript {
             'This file received a 500 response code. Verify on the website if this file is not downloadable'
           )
           return ''
+        } else if (errorStatus === 502) {
+          this.log(
+            'warn',
+            'Website is struggling to get the wanted bill, retry later'
+          )
+          return ''
         } else {
           errorToLog = 'Website server error accessing the wanted URL'
         }


### PR DESCRIPTION
This PR changes an awaited element for the "monCompte" page. It was waiting for a userID to show up in the sessionStorage but this was very unstable, leading the konnector to find itself crashing because none of the condition was ever coming to resolve the race. 
It also adds a blank return when bills are not sent properly by the website when trying to download. Once in a while, website did not manage to send the requested file, responding with a 502, leading to crashes. It now takes in consideration the specifique 502 response and return an empty string to saveFiles with a specific "warn" log so we know there is a problem. 
With that being said, it appears that rerun the konnector will usually download the previous run's missing file(s)